### PR TITLE
日程と場所を確定

### DIFF
--- a/_includes/index/en/info.html
+++ b/_includes/index/en/info.html
@@ -13,26 +13,35 @@
         <tr>
           <th>Dates</th>
           <td>
-            27th - 29th June, 2019 in Tokyo (The schedule is tentative.)
+            27th - 29th June, 2019 in Tokyo
           </td>
         </tr>
         <tr>
           <th>Venue</th>
           <td>
-            Tokyo International Exchange Center (The venue is tentative.)
-          </td>
+             <div>
+              <a href="http://www.jasso.go.jp/tiec/index_e.html" target="_blank">
+          	 Tokyo International Exchange Center
+              </a>
+             </div>
+             <div class="gmap-wrap">
+                <iframe
+                    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4726.348770160201!2d139.7801964987376!3d35.62420849277758!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x601889fec03298c3%3A0x580ab4984e28a750!2z5p2x5Lqs5Zu96Zqb5Lqk5rWB6aSoIOODl-ODqeOCtuW5s-aIkA!5e0!3m2!1sja!2sjp!4v1521255344640"
+                    width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+             </div>
+	  </td>
         </tr>
         <tr>
           <th>Tickets</th>
           <td>
+	      Tickets are still not on sale. Please follow our twitter account or facebook account for updates.
             <!--Please purchase the tickets from <a href='https://scalaconfjp.doorkeeper.jp/events/{{ site.doorkeeper.event.id }}'>DoorKeeper</a>.-->
           </td>
         </tr>
       </table>
       <p>
-        We announce the news at <a href="https://twitter.com/scala_jp">twitter</a>
-        and <a href="https://www.facebook.com/ScalaMatsuri">facebook</a>.
-        Please follow/like.
+        Please follow us on <a href="https://twitter.com/scala_jp">Twitter</a> or 
+	<a href="https://www.facebook.com/ScalaMatsuri">Facebook</a> to receive the latest updates.
       </p>
     </div>
   </div>

--- a/_includes/index/ja/info.html
+++ b/_includes/index/ja/info.html
@@ -13,26 +13,37 @@
         <tr>
           <th>日程</th>
           <td>
-            2019年6月27日(木)、6月28日(金)、6月29日(土)(開催日は変更の可能性があります)
+            2019年6月27日(木)、6月28日(金)、6月29日(土)
           </td>
         </tr>
         <tr>
           <th>会場</th>
-          <td>東京国際交流館(仮)</td>
+          <td>
+		<div>
+                  <a href="http://www.jasso.go.jp/tiec/plazaheisei.html" target="_blank">
+                    東京国際交流館
+                  </a>
+                </div>
+                <div class="gmap-wrap">
+                  <iframe
+                    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4726.348770160201!2d139.7801964987376!3d35.62420849277758!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x601889fec03298c3%3A0x580ab4984e28a750!2z5p2x5Lqs5Zu96Zqb5Lqk5rWB6aSoIOODl-ODqeOCtuW5s-aIkA!5e0!3m2!1sja!2sjp!4v1521255344640"
+                    width="400" height="300" frameborder="0" style="border:0" allowfullscreen></iframe>
+                </div>
+	  </td>
         </tr>
 
         <tr>
           <th>チケット</th>
           <td>
-            参加にはチケットが必要です。
+            参加するには発売時期未定のチケットが必要です。発売情報は公式TwitterないしはFacebookアカウントでアナウンスします。
             <!--<a href='https://scalaconfjp.doorkeeper.jp/events/{{ site.doorkeeper.event.id }}'>こちら</a>からご購入下さい。-->
           </td>
         </tr>
 
       </table>
       <p>
-        <a href="https://twitter.com/scala_jp">twitter</a>や
-        <a href="https://www.facebook.com/ScalaMatsuri">facebook</a>
+        <a href="https://twitter.com/scala_jp">Twitter</a>や
+        <a href="https://www.facebook.com/ScalaMatsuri">Facebook</a>
         でも随時情報を発信していますので、是非フォロー/いいねをお願いします。
       </p>
     </div>


### PR DESCRIPTION
ScalaDaysの日程確定まで「変更の可能性あり」と記載していましたが、今回6/11-13に確定したことを受けて、ScalaMatsuriの日程も確定します。
ついでに細々した文言の修正も行っています。

https://scaladays.org/