### PR TITLE
スポンサー募集のお知らせをトップページにも掲載

### DIFF
--- a/_includes/index/ja/sponsorship.html
+++ b/_includes/index/ja/sponsorship.html
@@ -1,0 +1,16 @@
+<section class="sectionStyle5">
+  <header class="sectionHeadArea">
+    <h2 class="clearfix">
+      <span class="ttlSubLCenter">スポンサー募集</span>
+      <span class="ttlSubLLeft"><img src="/img/common/ttl_dots_left.png"></span>
+      <span class="ttlSubLRight"><img src="/img/common/ttl_dots_right.png"></span>
+    </h2>
+    <p class="subTtlSm">Sponsorship</p>
+  </header>
+  <div class="sectionStyle1Inner">
+    <div class="txtBlock">
+	    <p>アジア最大級の国際Scalaカンファレンスである、ScalaMatsuriに協賛いただけるスポンサー様を募集しています。</p>
+	    <p>詳細は<a href="/ja/sponsors/">スポンサー募集ページ</a>をご覧ください。</p>
+    </div>
+  </div>
+</section>

--- a/index.html
+++ b/index.html
@@ -84,6 +84,8 @@ layout: null
 
   {% include index/ja/info.html %}
 
+  {% include index/ja/sponsorship.html %}
+
   {% include index/ja/social.html %}
 
   {% include index/ja/coc.html %}


### PR DESCRIPTION
トップページにリンクがないと分かりにくいという指摘があったため修正。