### PR TITLE
問い合わせフォームのリンクを修正

### DIFF
--- a/_includes/index/ja/contacts.html
+++ b/_includes/index/ja/contacts.html
@@ -9,7 +9,7 @@
   <div class="txtBlock">
     <p>
       ScalaMatsuri については
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfiRa3AIShPAPaZJ5o1sKfdvUzwMlP6Mysw_qnVsI9o1zocuw/viewform">
+      <a href="https://docs.google.com/forms/d/e/1FAIpQLScHAjizfrX-M-m6GpRmJNvH-2D-6DjOGcK9FE23l6csgoceSw/viewform">
         こちらのフォーム
       </a>
       からお問い合わせください。


### PR DESCRIPTION
問い合わせフォームが以下のSSのように使えなくなってしまっていたので、差し替え。
![ss](https://user-images.githubusercontent.com/1506707/50589076-6909aa80-0ec8-11e9-80b4-64ccafd35740.png)
