### PR TITLE
remove jekyll incremental flag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
       - "4000:4000"
     expose:
       - 4000
-    command: "bundle exec jekyll s --watch --incremental --force_polling -H 0.0.0.0"
+    command: "bundle exec jekyll s --watch --force_polling -H 0.0.0.0"


### PR DESCRIPTION
Jekyllの `--incremental` flagを指定していると、ロゴやnoticeの追加を差分と認識せず、jekyllがサイトを再生成しないことがあるという問題があります。
（毎回ではないです。`--incremental` flagがexperimentalであることが原因なのかもしれません。）

https://jekyllrb.com/docs/configuration/incremental-regeneration/

現在のWebサイトの更新は、ロゴやnotice、candidatesの追加がほとんどなので、`--incremental` の恩恵が薄いことを考えると、このflagは消してしまっても良いように思います。