### PR TITLE
モバイルでも順位づけ投票可能にする

### DIFF
--- a/_layouts/default_en.html
+++ b/_layouts/default_en.html
@@ -49,6 +49,7 @@
   <script src="https://www.gstatic.com/firebasejs/4.8.0/firebase.js"></script>
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+  <script src="/js/jquery.ui.touch-punch.min.js"></script>
 </head>
 <body>
 <header class="pageHeader">

--- a/_layouts/default_ja.html
+++ b/_layouts/default_ja.html
@@ -49,6 +49,7 @@
   <script src="https://www.gstatic.com/firebasejs/4.8.0/firebase.js"></script>
   <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.css">
   <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js"></script>
+  <script src="/js/jquery.ui.touch-punch.min.js"></script>
 </head>
 <body>
 <header class="pageHeader">

--- a/js/jquery.ui.touch-punch.min.js
+++ b/js/jquery.ui.touch-punch.min.js
@@ -1,0 +1,11 @@
+/*!
+ * jQuery UI Touch Punch 0.2.3
+ *
+ * Copyright 2011–2014, Dave Furfero
+ * Dual licensed under the MIT or GPL Version 2 licenses.
+ *
+ * Depends:
+ *  jquery.ui.widget.js
+ *  jquery.ui.mouse.js
+ */
+!function(a){function f(a,b){if(!(a.originalEvent.touches.length>1)){a.preventDefault();var c=a.originalEvent.changedTouches[0],d=document.createEvent("MouseEvents");d.initMouseEvent(b,!0,!0,window,1,c.screenX,c.screenY,c.clientX,c.clientY,!1,!1,!1,!1,0,null),a.target.dispatchEvent(d)}}if(a.support.touch="ontouchend"in document,a.support.touch){var e,b=a.ui.mouse.prototype,c=b._mouseInit,d=b._mouseDestroy;b._touchStart=function(a){var b=this;!e&&b._mouseCapture(a.originalEvent.changedTouches[0])&&(e=!0,b._touchMoved=!1,f(a,"mouseover"),f(a,"mousemove"),f(a,"mousedown"))},b._touchMove=function(a){e&&(this._touchMoved=!0,f(a,"mousemove"))},b._touchEnd=function(a){e&&(f(a,"mouseup"),f(a,"mouseout"),this._touchMoved||f(a,"click"),e=!1)},b._mouseInit=function(){var b=this;b.element.bind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),c.call(b)},b._mouseDestroy=function(){var b=this;b.element.unbind({touchstart:a.proxy(b,"_touchStart"),touchmove:a.proxy(b,"_touchMove"),touchend:a.proxy(b,"_touchEnd")}),d.call(b)}}}(jQuery);


### PR DESCRIPTION
現状、モバイルではドラッグ＆ドロップできず、従って順位づけすることがこんなんです。

そこで、jQuery UI Touch Punchを使って、モバイルでもドラッグ＆ドロップ可能にしてみました。
モバイル対応なのでローカルでは試せていないのですが、少なくともPCブラウザ上でのdrag&dropの挙動は大丈夫そうなのでmergeしていただき、ダメそうならまた対応考えます。

http://touchpunch.furf.com/