### PR TITLE
営業終了したホテルへのリンクを削除

### DIFF
--- a/en/travel/index.html
+++ b/en/travel/index.html
@@ -24,7 +24,6 @@ If you're receiving travel support from us, please book your flight as soon as p
 <table>
     <tr><td>Hotel</td><td>Supported Languages</td></tr>
     <tr><td><a href="http://tokyobay.washington-hotels.jp/">Tokyo Bay Ariake Washington Hotel(Recommended)</a></td><td>English</td></tr>
-    <tr><td><a href="http://www.oakwood-ariake.com/">Oakwood Hotel &amp; Apartment Ariake</a></td><td>English,Chinese,Indonesian</td></tr>
     <tr><td><a href="http://www.tokyustay.co.jp/e/hotel/SHI/">Tokyu Stay Shimbashi</a></td><td>English</td></tr>
     <tr><td><a href="http://www.gardenhotels.co.jp/eng/shiodome-italiagai/">Mitsui Garden Hotel Shiodome Italia-gai</a></td><td>English</td></tr>
     <tr><td><a href="http://www.hotelsunrouteariake.jp">Hotel Sunroute Ariake</a></td><td>English</td></tr>

--- a/ja/travel/index.html
+++ b/ja/travel/index.html
@@ -11,7 +11,6 @@ title: トラベル情報
 <table>
     <tr><td>ホテル名</td><td>対応言語</td></tr>
     <tr><td><a href="http://tokyobay.washington-hotels.jp/">東京ベイ有明ワシントンホテル(推奨)</a></td><td>English</td></tr>
-    <tr><td><a href="http://www.oakwood-ariake.com/">オークウッドホテル &amp; アパーツメンツ有明</a></td><td>English,Chinese,Indonesian</td></tr>
     <tr><td><a href="http://www.tokyustay.co.jp/e/hotel/SHI/">東急ステイ新橋</a></td><td>English</td></tr>
     <tr><td><a href="http://www.gardenhotels.co.jp/eng/shiodome-italiagai/">三井ガーデンホテル汐留イタリア街</a></td><td>English</td></tr>
     <tr><td><a href="http://www.hotelsunrouteariake.jp">ホテルサンルート有明</a></td><td>English</td></tr>


### PR DESCRIPTION
オークウッドホテル & アパートメンツ有明は営業終了したようです。
https://oakwood.jp/images/pdf/ariake.pdf
( http://www.oakwood-ariake.com/ からのリダイレクト先になっています)