### PR TITLE
スポンサー募集を停止する

### DIFF
--- a/_data/nav_ja.yml
+++ b/_data/nav_ja.yml
@@ -22,5 +22,5 @@
   title: トラベル情報
 - href: "/ja/extra-staff"
   title: 当日スタッフ募集
-- href: "/ja/sponsors/"
-  title: スポンサー募集
+# - href: "/ja/sponsors/"
+#  title: スポンサー募集


### PR DESCRIPTION
6/12 23:59にスポンサー募集を締め切るので、それ以降にmergeします。

合わせて、スポンサー申し込みフォームも申し込みができないように別途変更します。