### PR TITLE
Travel grantの宿泊費の説明に日付を追加

### DIFF
--- a/en/cfp/index.md
+++ b/en/cfp/index.md
@@ -55,7 +55,7 @@ Because ScalaMatsuri is run by a non-profit association, the travel grant must o
 
 1. Airfare and other transportation to Tokyo.
 2. Other transportation during ScalaMatsuri
-3. Hotel fares during ScalaMatsuri sessions.
+3. Hotel fares during ScalaMatsuri sessions. (June 26th, 2019 checkin - June 30th checkout)
 
 Any other expenses, including ones incurred from sightseeing or hotel fares (priced per person in Japan) for accompanying travellers, cannot be expensed by us.
 


### PR DESCRIPTION
TravelGrantの宿泊費の説明部分について、日付（いつからいつまでの宿泊が旅費助成金の対象になるのか）を追加しておきたいです。

このページをOPENしたときに、ScalaMatsuri2019の開催日がFIXしておらず説明に入れられていなかったかと思います。ScalaMatsuri2018のWebサイトにも同じページがあるのですが、そこには日付が入っているので、来期忘れないよう追加しておきたいです。

なお、この説明自体はスピーカーへのメールに書いてあるので案内漏れではないです、ご安心を。